### PR TITLE
Launch deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.3.0
+
+Added:
+* Ability to load dependencies on script launch. [Example](./example-scripts/launch_deps.clj)
+
+Fixed:
+* Unit Tests
+
 # 0.2.1
 
 Fixed:

--- a/cljog
+++ b/cljog
@@ -17,6 +17,7 @@ hash clojure 2>/dev/null || error_exit 'Clojure tools not found. Refer https://c
 
 CLJ_OPTS='-J-Xms256m -J-Xmx256m -J-client -J-XX:MaxMetaspaceSize=100m -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-XX:+UseConcMarkSweepGC -J-XX:+CMSClassUnloadingEnabled -J-Xverify:none -J-Dclojure.spec.skip-macros=true'
 VERSION=0.2.1
+LAUNCH_DEPS=''
 
 run_script(){ # path-to-script.clj & args
 	local args='['
@@ -61,12 +62,16 @@ run_script(){ # path-to-script.clj & args
   nil)
 EOF
 
+	if [[ ! -z ${LAUNCH_DEPS} ]];then
+		echo "Running $1 with extra dependencies: $LAUNCH_DEPS"
+	fi
 	#language=clj
-	local DEPS='
-  {:deps          {com.cemerick/pomegranate {:mvn/version "1.1.0" :exclusions [commons-logging]}
-                   org.slf4j/slf4j-nop      {:mvn/version "1.7.22"}}
-   :override-deps {org.slf4j/slf4j-api      {:mvn/version "1.7.22"}
-                   org.slf4j/jcl-over-slf4j {:mvn/version "1.7.22"}}}'
+	local DEPS="
+  {:deps          {com.cemerick/pomegranate {:mvn/version \"1.1.0\" :exclusions [commons-logging]}
+                   $LAUNCH_DEPS
+                   org.slf4j/slf4j-nop      {:mvn/version \"1.7.22\"}}
+   :override-deps {org.slf4j/slf4j-api      {:mvn/version \"1.7.22\"}
+                   org.slf4j/jcl-over-slf4j {:mvn/version \"1.7.22\"}}}"
   exec clojure $CLJ_OPTS -Sdeps "$DEPS" -e "$clj_script"
 }
 
@@ -261,6 +266,11 @@ else
 	}
 
 	case "$1" in
+		--launch-deps)
+			len=${#@}
+			LAUNCH_DEPS="${@:2:$len-2}"
+			file="${@:$len}"
+			run_script "$file";;
 		--config)
 			log "${config_file}\n"
 			cat ${config_file};;

--- a/cljog
+++ b/cljog
@@ -16,7 +16,7 @@ define(){ IFS='\n' read -r -d '' ${1} || true; }
 hash clojure 2>/dev/null || error_exit 'Clojure tools not found. Refer https://clojure.org/guides/deps_and_cli'
 
 CLJ_OPTS='-J-Xms256m -J-Xmx256m -J-client -J-XX:MaxMetaspaceSize=100m -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-XX:+UseConcMarkSweepGC -J-XX:+CMSClassUnloadingEnabled -J-Xverify:none -J-Dclojure.spec.skip-macros=true'
-VERSION=0.2.1
+VERSION=0.3.0
 LAUNCH_DEPS=''
 
 run_script(){ # path-to-script.clj & args

--- a/example-scripts/launch_deps.clj
+++ b/example-scripts/launch_deps.clj
@@ -1,0 +1,3 @@
+#!/usr/bin/env cljog --launch-deps io.jesi/backpack {:mvn/version "4.2.1"}
+(require '[io.jesi.backpack.random :as rnd])
+(println (rnd/uuid-str))

--- a/tests/miscellaneous.bats
+++ b/tests/miscellaneous.bats
@@ -33,7 +33,7 @@ assert_help () {
 @test "prints the current version" {
 	run ./cljog --version
 	[[ "$status" -eq 0 ]]
-	[[ "${lines[0]}" == "0.2.0" ]]
+	[[ "${lines[0]}" == "0.3.0" ]]
 }
 
 @test "prints help if given no args" {

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1,18 +1,26 @@
 #!/usr/bin/env bats
 
 @test "can run scripts that include dependencies" {
-	run ./cljog example-scripts/echo.clj first-arg second-arg "third arg is a string"
+	run example-scripts/echo.clj first-arg second-arg "third arg is a string"
 	[[ "$status" -eq 0 ]]
 	[[ "${lines[0]}" == "Hello! from the other side" ]]
 	[[ "${lines[1]}" == "Script: example-scripts/echo.clj" ]]
 	[[ "${lines[2]}" == "Current working dir: /Users/xander/Projects/cljog" ]]
 	[[ "${lines[3]}" == "Clojure version: {:major 1,"* ]]
-	[[ "${lines[4]}" == "cljog version: 0.2.0" ]]
+	[[ "${lines[4]}" == "cljog version: 0.3.0" ]]
 	[[ "${lines[5]}" == "Command line args: [first-arg second-arg third arg is a string]" ]]
 	[[ "${lines[6]}" == "Random string:"* ]]
 }
 
 @test "scripts that throw uncaught exceptions have a non-zero exit code" {
-	run ./cljog example-scripts exception.clj
+	run example-scripts/exception.clj
 	[[ "$status" -eq 1 ]]
+}
+
+@test "scripts with --launch-deps have dependencies available" {
+	run example-scripts/launch_deps.clj
+	echo "${lines[1]}"
+	[[ "$status" -eq 0 ]]
+	[[ "${lines[0]}" == "Running example-scripts/launch_deps.clj with extra dependencies:"* ]]
+	[[ "${lines[1]}" =~ ^\{?[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{12}\}?$ ]]
 }


### PR DESCRIPTION
Some dependencies (like `clj-tuple`) do not like being dynamically loaded.

The ability to specify extra `--launch-deps` for a script ensures that these dependencies are loaded as `cljog` starts up. 
